### PR TITLE
TC-239: Adds option to not create Django users if one is not found

### DIFF
--- a/pyauth0jwtrest/settings.py
+++ b/pyauth0jwtrest/settings.py
@@ -12,7 +12,7 @@ DEFAULTS = {
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
     'USERNAME_FIELD': 'email',
     'JWT_PAYLOAD_GET_USERNAME_HANDLER': 'pyauth0jwtrest.utils.auth0_get_username_from_payload_handler',
-    'CREATE_USERS': True,
+    'REQUIRE_USERS': True,
     'CLIENT_SECRET_BASE64_ENCODED': True,
     'CLIENT_SECRET': getattr(settings, 'AUTH0_CLIENT_SECRET', None),
 }

--- a/pyauth0jwtrest/utils.py
+++ b/pyauth0jwtrest/utils.py
@@ -1,4 +1,6 @@
 import requests
+import jwt
+
 from cryptography.x509 import load_pem_x509_certificate
 from cryptography.hazmat.backends import default_backend
 
@@ -14,7 +16,6 @@ from pyauth0jwtrest.settings import auth0_api_settings
 def auth0_get_username_from_payload_handler(payload):
     username = payload.get(auth0_api_settings.USERNAME_FIELD)
     return username
-
 
 # Authorization Utils ---------------------------------------------------------
 def get_jwt_value(request):
@@ -34,6 +35,9 @@ def get_jwt_value(request):
 
     return auth[1]
 
+def get_email_from_request(request):
+    jwt_value = get_jwt_value(request)
+    return str(jwt.decode(jwt_value, verify=False)['email'])
 
 def get_auth0_public_key(auth0_domain):
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='py-auth0-jwt-rest',
-    version='0.1.4',
+    version='0.1.7',
     url='https://github.com/hms-dbmi/py-auth0-jwt-rest',
     author='HMS DBMI Tech-core',
     author_email='dbmi-tech-core@hms.harvard.edu',


### PR DESCRIPTION
Needed for userless microservices such as SciAuthZ (and eventually SciReg, SciAuth). Also adds a get_email_from_request() method so apps can pull the email out of the JWT easily.